### PR TITLE
E2e

### DIFF
--- a/.github/workflows/contacts-ci-cd.yml
+++ b/.github/workflows/contacts-ci-cd.yml
@@ -29,8 +29,16 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
+      - run: npm run test:e2e
+      - name: Save e2e test data
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-data
+          path: |
+            contacts/src/e2e-tests/.test-data/
+          retention-days: 1
       - name: Save build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: |

--- a/.github/workflows/contacts-ci-cd.yml
+++ b/.github/workflows/contacts-ci-cd.yml
@@ -5,9 +5,6 @@ on:
     paths:
       - contacts/**
       - .github/workflows/contacts-ci-cd.yml
-  pull_request:
-    paths:
-      - contacts/**
 
 jobs:
   build:

--- a/contacts/.gitignore
+++ b/contacts/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 dev-server/data/
+src/e2e-tests/.test-data

--- a/contacts/README.md
+++ b/contacts/README.md
@@ -19,13 +19,13 @@ npm test
 
 ### End-to-end tests
 
-Those tests need the development server running and initialized, please follow the instruction in the section "Development server" before running the tests.
-
-After that you can start the tests via
+The tests will start and stop their own solid server on port `3456`. This port needs to be available.
 
 ```shell
 npm run test:e2e
 ```
+
+The server is seeded with data from `src/e2e-tests/test-data` initially. After a test run you can investigate the pod file system at `src/e2e-tests/.test-data/<test-id>` where `<test-id>` is a random id generated for each run.
 
 ## Build
 

--- a/contacts/jest.e2e.config.js
+++ b/contacts/jest.e2e.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   rootDir: "src/e2e-tests",
+  testTimeout: 60000,
 };

--- a/contacts/src/e2e-tests/config.json
+++ b/contacts/src/e2e-tests/config.json
@@ -1,0 +1,38 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld"
+  ],
+  "import": [
+    "css:config/app/init/initialize-intro.json",
+    "css:config/app/main/default.json",
+    "css:config/app/variables/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/all.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/default.json",
+    "css:config/identity/oidc/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/ldp/authentication/dpop-bearer.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+    "css:config/storage/backend/file.json",
+    "css:config/storage/key-value/resource-store.json",
+    "css:config/storage/location/root.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/resource-locker/memory.json",
+    "css:config/util/variables/default.json"
+  ]
+}

--- a/contacts/src/e2e-tests/contacts.e2e.spec.ts
+++ b/contacts/src/e2e-tests/contacts.e2e.spec.ts
@@ -1,20 +1,54 @@
 import { Fetcher, graph, UpdateManager } from "rdflib";
 import { ContactsModule } from "../rdflib";
 import { faker } from "@faker-js/faker";
+import { startServer } from "./start-server";
+import { v4 as uuid } from "uuid";
 
 describe("contacts module", () => {
-  beforeAll(async () => {
-    const response = await fetch("http://localhost:3000/alice/");
+  const testId = uuid();
+  beforeAll(async (): Promise<void> => {
+    await startServer(testId);
+  });
+
+  it("can fetch from the test server", async () => {
+    const response = await fetch("http://localhost:3456/");
     expect(response.status).toBe(200);
   });
+
+  it("can create a new address book", async () => {
+    const contacts = setupModule();
+    const uri = await contacts.createAddressBook({
+      container: "http://localhost:3456/",
+      name: "Personal contacts",
+    });
+    expect(uri).toMatch(
+      new RegExp("http://localhost:3456/[a-z\\-0-9]+/index.ttl#this"),
+    );
+  });
+
+  it("can read an existing address book", async () => {
+    const contacts = setupModule();
+    const result = await contacts.readAddressBook(
+      "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/index.ttl#this",
+    );
+    expect(result).toEqual({
+      uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/index.ttl#this",
+      title: "Personal contacts",
+      contacts: [
+        {
+          uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this",
+          name: "Molly Braaten",
+        },
+      ],
+      groups: [],
+    });
+  });
+
   it("can create a new contact within an existing address book", async () => {
-    const store = graph();
-    const fetcher = new Fetcher(store);
-    const updater = new UpdateManager(store);
-    const contacts = new ContactsModule({ store, fetcher, updater });
+    const contacts = setupModule();
 
     const addressBook =
-      "http://localhost:3000/alice/public-write/ab9694d6-120e-415d-a315-90cd84c2e062/index.ttl#this";
+      "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/index.ttl#this";
 
     const name = faker.person.fullName();
     const uri = await contacts.createNewContact({
@@ -33,39 +67,43 @@ describe("contacts module", () => {
   });
 
   it("can read a existing contact", async () => {
-    const store = graph();
-    const fetcher = new Fetcher(store);
-    const updater = new UpdateManager(store);
-    const contacts = new ContactsModule({ store, fetcher, updater });
+    const contacts = setupModule();
 
     const contactUri =
-      "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this";
+      "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this";
 
     const result = await contacts.readContact(contactUri);
 
     expect(result).toEqual({
-      uri: "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this",
+      uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this",
       name: "Molly Braaten",
       emails: [
         {
-          uri: "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702497197769",
+          uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702497197769",
           value: "molly.braaten@gov.test",
         },
         {
-          uri: "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702500031124",
+          uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702500031124",
           value: "molly.braaten@home.test",
         },
       ],
       phoneNumbers: [
         {
-          uri: "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702497210116",
+          uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702497210116",
           value: "+1234567890",
         },
         {
-          uri: "http://localhost:3000/alice/public-contacts/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702500092868",
+          uri: "http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#id1702500092868",
           value: "+0987654321",
         },
       ],
     });
   });
 });
+
+function setupModule() {
+  const store = graph();
+  const fetcher = new Fetcher(store);
+  const updater = new UpdateManager(store);
+  return new ContactsModule({ store, fetcher, updater });
+}

--- a/contacts/src/e2e-tests/start-server.ts
+++ b/contacts/src/e2e-tests/start-server.ts
@@ -1,0 +1,27 @@
+import { AppRunner, joinFilePath } from "@solid/community-server";
+
+import { cp } from "fs/promises";
+
+export async function startServer(id: string) {
+  const testDataPath = joinFilePath(__dirname, "test-data");
+  const rootFilePath = joinFilePath(__dirname, ".test-data", id);
+  const app = await new AppRunner().create({
+    config: joinFilePath(__dirname, "./config.json"),
+    loaderProperties: {
+      mainModulePath: joinFilePath(__dirname, "../"),
+      dumpErrorState: false,
+    },
+    shorthand: {
+      port: 3456,
+      loggingLevel: "off",
+      rootFilePath: rootFilePath,
+    },
+    variableBindings: {},
+  });
+
+  await app.start();
+
+  await cp(testDataPath, rootFilePath, { recursive: true });
+
+  return app;
+}

--- a/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl
+++ b/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl
@@ -1,0 +1,21 @@
+<#this>
+    <http://www.w3.org/2006/vcard/ns#fn>           "Molly Braaten" ;
+    a                                              <http://www.w3.org/2006/vcard/ns#Individual> ;
+    <http://www.w3.org/2006/vcard/ns#hasEmail>     <#id1702497197769>, <#id1702500031124> ;
+    <http://www.w3.org/2006/vcard/ns#hasTelephone> <#id1702497210116>, <#id1702500092868> .
+
+<#id1702497197769>
+    a                                       <http://www.w3.org/2006/vcard/ns#Work> ;
+    <http://www.w3.org/2006/vcard/ns#value> <mailto:molly.braaten@gov.test> .
+
+<#id1702500031124>
+    a                                       <http://www.w3.org/2006/vcard/ns#Home> ;
+    <http://www.w3.org/2006/vcard/ns#value> <mailto:molly.braaten@home.test> .
+
+<#id1702497210116>
+    a                                       <http://www.w3.org/2006/vcard/ns#Work> ;
+    <http://www.w3.org/2006/vcard/ns#value> <tel:+1234567890> .
+
+<#id1702500092868>
+    a                                       <http://www.w3.org/2006/vcard/ns#Cell> ;
+    <http://www.w3.org/2006/vcard/ns#value> <tel:+0987654321> .

--- a/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/index.ttl
+++ b/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/index.ttl
@@ -1,0 +1,4 @@
+<#this> a <http://www.w3.org/2006/vcard/ns#AddressBook>;
+    <http://purl.org/dc/elements/1.1/title> "Personal contacts";
+    <http://www.w3.org/2006/vcard/ns#nameEmailIndex> <http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/people.ttl>;
+    <http://www.w3.org/2006/vcard/ns#groupIndex> <http://localhost:3456/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/groups.ttl>.

--- a/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/people.ttl
+++ b/contacts/src/e2e-tests/test-data/4243dbb6-3126-4bf9-9ea7-45e35c3c8d9d/people.ttl
@@ -1,0 +1,6 @@
+@prefix :       <#> .
+@prefix vcard:  <http://www.w3.org/2006/vcard/ns#> .
+
+<Person/1973dcec-e71c-476c-87db-0d3332291214/index.ttl#this>
+    vcard:inAddressBook <index.ttl#this> ;
+    vcard:fn            "Molly Braaten" .


### PR DESCRIPTION
Builds on https://github.com/solid-contrib/data-modules/pull/58

This PR makes the e2e test independent of a running dev server. Instead the tests spin up their own CSS test server programmatically. This allows to include the e2e tests into the pipeline as well.